### PR TITLE
Release v0.4.2

### DIFF
--- a/ioc_cli/__init__.py
+++ b/ioc_cli/__init__.py
@@ -188,7 +188,7 @@ class IOCageCLI(click.MultiCommand):
     help="Globally override the activated iocage dataset(s)"
 )
 @click.command(cls=IOCageCLI)
-@click.version_option(version="0.4.1 2019/01/05", prog_name="ioc")
+@click.version_option(version="0.4.2 2019/01/10", prog_name="ioc")
 @click.pass_context
 def cli(ctx, log_level: str, source: set) -> None:
     """A jail manager."""

--- a/ioc_cli/set.py
+++ b/ioc_cli/set.py
@@ -57,10 +57,14 @@ def cli(
 
     # Defaults
     if jail == "defaults":
-        updated_properties = set_properties(
-            properties=props,
-            target=host.defaults
-        )
+        try:
+            updated_properties = set_properties(
+                properties=props,
+                target=host.defaults
+            )
+        except ioc.errors.IocageException:
+            exit(1)
+
         if len(updated_properties) > 0:
             logger.screen("Defaults updated: " + ", ".join(updated_properties))
         else:

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ if sys.version_info < (3, 6):
 setup(
     name='ioc_cli',
     license='BSD',
-    version='0.4.0',
+    version='0.4.2',
     description='A Python library to manage jails with iocage',
     keywords='FreeBSD jail iocage ioc',
     author='ioc Contributors',


### PR DESCRIPTION
- exit without stacktrace when setting unknown default config properties
- upgrade libioc to [v0.4.2](https://github.com/bsdci/libioc/releases/tag/0.4.2)