### PR TITLE
do not save temporary jail properties on start or provision commands

### DIFF
--- a/ioc_cli/provision.py
+++ b/ioc_cli/provision.py
@@ -92,7 +92,8 @@ def _provision(
         try:
             set_properties(
                 properties=temporary_config_override,
-                target=jail
+                target=jail,
+                autosave=False
             )
         except libioc.errors.IocException:
             exit(1)

--- a/ioc_cli/shared/jail.py
+++ b/ioc_cli/shared/jail.py
@@ -49,7 +49,8 @@ def get_jail(
 
 def set_properties(
     properties: typing.Iterable[str],
-    target: 'libioc.LaunchableResource.LaunchableResource'
+    target: 'libioc.LaunchableResource.LaunchableResource',
+    autosave: bool=True
 ) -> set:
     """Set a bunch of jail properties from a Click option tuple."""
     updated_properties = set()
@@ -69,7 +70,7 @@ def set_properties(
             except (libioc.errors.IocException, KeyError):
                 pass
 
-    if len(updated_properties) > 0:
+    if (len(updated_properties) > 0) and (autosave is True):
         target.save()
 
     return updated_properties

--- a/ioc_cli/start.py
+++ b/ioc_cli/start.py
@@ -160,7 +160,8 @@ def _normal(
         try:
             set_properties(
                 properties=temporary_config_override,
-                target=jail
+                target=jail,
+                autosave=False
             )
         except libioc.errors.IocException:
             exit(1)


### PR DESCRIPTION
Fixes an issue where temporary JailConfig properties were saved on start or provision commands.