### PR TITLE
install pip on systems that do not have it yet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 deps:
 	# pkg install -q -y py36-ioc
+	python3.6 -m ensurepip
 	python3.6 -m pip install -Ur requirements.txt
 	git submodule init
 	git submodule update


### PR DESCRIPTION
fixes #15 

- ensure that pip is available before installing dependencies with it