### PR TITLE
Soft-fail starting jails skipped due to hostid mismatch

### DIFF
--- a/ioc_cli/start.py
+++ b/ioc_cli/start.py
@@ -119,6 +119,9 @@ def _autostart(
             if jail.running is True:
                 logger.log(f"{jail.name} is already running - skipping start")
                 continue
+            elif jail.hostid_check_ok is False:
+                logger.log(f"{jail.name} hostid mismatch - skipping start")
+                continue
             jail.start()
         except libioc.errors.IocException:
             failed_jails.append(jail)
@@ -169,6 +172,10 @@ def _normal(
             jail.require_jail_not_template()
             if jail.running is True:
                 logger.log(f"{jail.name} is already running - skipping start")
+                skipped_jails.append(jail)
+                continue
+            elif jail.hostid_check_ok is False:
+                logger.log(f"{jail.name} hostid mismatch - skipping start")
                 skipped_jails.append(jail)
                 continue
             print_function(jail.start())

--- a/ioc_cli/start.py
+++ b/ioc_cli/start.py
@@ -189,9 +189,12 @@ def _normal(
     if len(failed_jails) > 0:
         return False
 
-    if (len(changed_jails) == 0) and (len(skipped_jails) == 0):
+    if len(changed_jails) == 0:
         jails_input = " ".join(list(filters))
-        logger.error(f"No jails started your input: {jails_input}")
+        if len(skipped_jails) == 0:
+            logger.error(f"No jails matched your input: {jails_input}")
+        else:
+            logger.error(f"No jails were started: {jails_input}")
         return False
 
     return True


### PR DESCRIPTION
related to https://github.com/bsdci/libioc/issues/634

When attempting to start a jail with `hostid_strict_check` enabled and a hostid that does not match to the contents of the hosts `/etc/hostid` file, a log message is printed, but no error is caused on the comand, unless no jail was started at all (which leads to `exit(1)` and a message on STDERR).
