### PR TITLE
Release 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This Python module does not ship with a CLI tool. The project an installation in
 
 - ioc Handbook: https://bsdci.github.io/handbook
 - libioc Reference Documentation: https://bsdci.github.io/libioc
+- Gitter Chat: https://gitter.im/libioc/community
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ cd ioc
 make install
 ```
 
-At the current time ioc is not packaged or available in FreeBSD ports.
+At the current time ioc is not packaged or available in FreeBSD ports yet. A request for [sysutilc/ioc](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=234816) is in review on bugs.freebsd.org.
+
+This Python module does not ship with a CLI tool. The project an installation instructions can be foun on [bsdci/ioc](https://github.com/bsdci/ioc).
 
 ## Documentation
 

--- a/ioc_cli/__init__.py
+++ b/ioc_cli/__init__.py
@@ -187,7 +187,7 @@ class IOCageCLI(click.MultiCommand):
     help="Globally override the activated iocage dataset(s)"
 )
 @click.command(cls=IOCageCLI)
-@click.version_option(version="0.6.0 2019/02/08", prog_name="ioc")
+@click.version_option(version="0.7.0 2019/02/24", prog_name="ioc")
 @click.pass_context
 def cli(ctx, log_level: str, source: set) -> None:
     """A jail manager."""

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ if sys.version_info < (3, 6):
 setup(
     name='ioc_cli',
     license='BSD',
-    version='0.5.0',
+    version='0.7.0',
     description='A Python library to manage jails with iocage',
     keywords='FreeBSD jail iocage ioc',
     author='ioc Contributors',


### PR DESCRIPTION
## Chores
- Remove JailGenerator.stats.query() calls, as they are no longer required with libioc using [py-jail](https://github.com/gronke/py-jail).
- Link Gitter chat in README file