### PR TITLE
Properly handle UnknownConfigProperty when reading defaults

### DIFF
--- a/ioc_cli/get.py
+++ b/ioc_cli/get.py
@@ -94,7 +94,10 @@ def cli(
         exit(1)
 
     if _prop:
-        value = lookup_method(source_resource, _prop)
+        try:
+            value = lookup_method(source_resource, _prop)
+        except libioc.errors.IocException:
+            exit(1)
 
         if value:
             print(value)


### PR DESCRIPTION
fixes #24

blocked by https://github.com/bsdci/libioc/pull/686

### Expected Result
```
$ python3.6 . get invalid defaults
The config property 'invalid' is unknown
$ echo $?
1
```

### Prior Result
```console
$ python3.6 . get invalid defaults
The config property 'invalid' is unknown
-
$ echo $?
0
```