### PR TITLE
only warn about invalid config on list, set and get subcommands

### DIFF
--- a/ioc_cli/get.py
+++ b/ioc_cli/get.py
@@ -81,7 +81,8 @@ def cli(
             source_resource = libioc.Jail.Jail(
                 jail,
                 host=host,
-                logger=logger
+                logger=logger,
+                skip_invalid_config=True
             )
         except libioc.errors.JailNotFound:
             exit(1)

--- a/ioc_cli/list.py
+++ b/ioc_cli/list.py
@@ -118,6 +118,8 @@ def cli(
 
         else:
 
+            resource_kwargs = dict()
+
             if (dataset_type == "base"):
                 resources_class = libioc.Releases.ReleasesGenerator
                 columns = ["full_name"]
@@ -130,6 +132,7 @@ def cli(
                     in host.datasets.items()
                 ]
             else:
+                resource_kwargs["skip_invalid_config"] = True
                 resources_class = libioc.Jails.JailsGenerator
                 columns = _list_output_comumns(output, _long)
                 if dataset_type == "template":
@@ -143,7 +146,8 @@ def cli(
                     host=host,
                     zfs=ctx.parent.zfs,
                     # ToDo: allow quoted whitespaces from user inputs
-                    filters=filters
+                    filters=filters,
+                    **resource_kwargs
                 )
 
     except libioc.errors.IocException:

--- a/ioc_cli/set.py
+++ b/ioc_cli/set.py
@@ -76,7 +76,8 @@ def cli(
     ioc_jails = libioc.Jails.JailsGenerator(
         filters,
         host=host,
-        logger=logger
+        logger=logger,
+        skip_invalid_config=True
     )
 
     updated_jail_count = 0


### PR DESCRIPTION
When a jail had invalid configuration, it was not possible to edit the settings with the ioc CLI. This enhancement only warns when spotting such occasions for the list, get and set commands. A warning will be printed (with default print-level `warn`), but the config properties are ignored.

Other commands, such as start and stop, do not allow ignoring invalid configuration properties. The configuration must be sane before it is possible to use them.