### PR TITLE
autostart service depends on NETWORK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ install-libioc:
 	git submodule init
 	git submodule update
 	make -C .libioc/ install
-install-ioc: deps
+install-ioc: deps install-service
 	python3.6 -m pip install -U .
+install-service:
 	@if [ -f /usr/local/etc/init.d ]; then \
 		install -m 0755 rc.d/ioc /usr/local/etc/init.d; \
 	else \

--- a/ioc_cli/destroy.py
+++ b/ioc_cli/destroy.py
@@ -94,12 +94,16 @@ def cli(
     else:
         resources_class = libioc.Jails.JailsGenerator
 
-    resources = list(resources_class(
-        filters=filters,
-        zfs=ctx.parent.zfs,
-        host=ctx.parent.host,
-        logger=logger
-    ))
+    try:
+        resources = list(resources_class(
+            filters=filters,
+            zfs=ctx.parent.zfs,
+            host=ctx.parent.host,
+            logger=logger,
+            skip_invalid_config=True
+        ))
+    except libioc.errors.IocException:
+        exit(1)
 
     if len(resources) == 0:
         logger.error("No target matched your input")

--- a/ioc_cli/fstab.py
+++ b/ioc_cli/fstab.py
@@ -122,7 +122,7 @@ def cli_add(
     comment: typing.Optional[str]
 ) -> None:
     """Add lines to a jails fstab file."""
-    ioc_jail = get_jail(jail, ctx.parent)
+    ioc_jail = get_jail(jail, ctx.parent, skip_invalid_config=True)
 
     if len(destination) == 0:
         desination_path = source

--- a/ioc_cli/rename.py
+++ b/ioc_cli/rename.py
@@ -50,7 +50,8 @@ def cli(
             jail,
             logger=logger,
             zfs=ctx.parent.zfs,
-            host=ctx.parent.host
+            host=ctx.parent.host,
+            skip_invalid_config=True
         )
         print_function(ioc_jail.rename(name))
     except libioc.errors.IocException:

--- a/ioc_cli/restart.py
+++ b/ioc_cli/restart.py
@@ -71,12 +71,15 @@ def cli(
         logger.error("No jail selector provided")
         exit(1)
 
-    ioc_jails = libioc.Jails.JailsGenerator(
-        host=ctx.parent.host,
-        zfs=ctx.parent.zfs,
-        logger=logger,
-        filters=jails
-    )
+    try:
+        ioc_jails = libioc.Jails.JailsGenerator(
+            host=ctx.parent.host,
+            zfs=ctx.parent.zfs,
+            logger=logger,
+            filters=jails
+        )
+    except libioc.errors.IocException:
+        exit(1)
 
     changed_jails = []
     failed_jails = []

--- a/ioc_cli/set.py
+++ b/ioc_cli/set.py
@@ -71,14 +71,17 @@ def cli(
             logger.screen("Defaults unchanged")
         return
 
-    # Jail Properties
     filters = (f"name={jail}",)
-    ioc_jails = libioc.Jails.JailsGenerator(
-        filters,
-        host=host,
-        logger=logger,
-        skip_invalid_config=True
-    )
+
+    try:
+        ioc_jails = libioc.Jails.JailsGenerator(
+            filters,
+            host=host,
+            logger=logger,
+            skip_invalid_config=True
+        )
+    except libioc.errors.IocException:
+        exit(1)
 
     updated_jail_count = 0
 

--- a/ioc_cli/shared/jail.py
+++ b/ioc_cli/shared/jail.py
@@ -34,14 +34,16 @@ from .click import IocClickContext
 
 def get_jail(
     jail_name: str,
-    ctx: IocClickContext
+    ctx: IocClickContext,
+    **jail_args: typing.Any
 ) -> libioc.Jail.JailGenerator:
     """Return the jail matching the given name."""
     try:
         return libioc.Jail.JailGenerator(
             jail_name,
             logger=ctx.logger,
-            host=ctx.host
+            host=ctx.host,
+            **jail_args
         )
     except libioc.errors.IocException:
         exit(1)

--- a/ioc_cli/snapshot.py
+++ b/ioc_cli/snapshot.py
@@ -213,4 +213,4 @@ def _parse_identifier(
             )
         jail = identifier
 
-    return get_jail(jail, ctx), snapshot_name
+    return get_jail(jail, ctx, skip_invalid_config=True), snapshot_name

--- a/ioc_cli/stop.py
+++ b/ioc_cli/stop.py
@@ -103,7 +103,8 @@ def _normal(
         zfs=zfs,
         host=host,
         logger=logger,
-        filters=filters
+        filters=filters,
+        skip_invalid_config=True
     )
 
     changed_jails = []
@@ -146,7 +147,8 @@ def _autostop(
         host=host,
         zfs=zfs,
         logger=logger,
-        filters=filters
+        filters=filters,
+        skip_invalid_config=True
     )
 
     # sort jails by their priority

--- a/ioc_cli/stop.py
+++ b/ioc_cli/stop.py
@@ -99,13 +99,16 @@ def _normal(
 
     filters += ("template=no,-",)
 
-    jails = libioc.Jails.JailsGenerator(
-        zfs=zfs,
-        host=host,
-        logger=logger,
-        filters=filters,
-        skip_invalid_config=True
-    )
+    try:
+        jails = libioc.Jails.JailsGenerator(
+            zfs=zfs,
+            host=host,
+            logger=logger,
+            filters=filters,
+            skip_invalid_config=True
+        )
+    except libioc.errors.IocException:
+        exit(1)
 
     changed_jails = []
     failed_jails = []
@@ -143,13 +146,16 @@ def _autostop(
 
     filters = ("running=yes", "template=no,-",)
 
-    ioc_jails = libioc.Jails.Jails(
-        host=host,
-        zfs=zfs,
-        logger=logger,
-        filters=filters,
-        skip_invalid_config=True
-    )
+    try:
+        ioc_jails = libioc.Jails.Jails(
+            host=host,
+            zfs=zfs,
+            logger=logger,
+            filters=filters,
+            skip_invalid_config=True
+        )
+    except libioc.errors.IocException:
+        exit(1)
 
     # sort jails by their priority
     jails = reversed(sorted(

--- a/ioc_cli/update.py
+++ b/ioc_cli/update.py
@@ -62,12 +62,15 @@ def cli(
         exit(1)
 
     filters = jails + ("template=no,-",)
-    ioc_jails = libioc.Jails.JailsGenerator(
-        logger=logger,
-        host=ctx.parent.host,
-        zfs=ctx.parent.zfs,
-        filters=filters
-    )
+    try:
+        ioc_jails = libioc.Jails.JailsGenerator(
+            logger=logger,
+            host=ctx.parent.host,
+            zfs=ctx.parent.zfs,
+            filters=filters
+        )
+    except libioc.errors.IocException:
+        exit(1)
 
     changed_jails = []
     failed_jails = []

--- a/rc.d/ioc
+++ b/rc.d/ioc
@@ -4,7 +4,7 @@
 #
 
 # PROVIDE: ioc
-# REQUIRE: LOGIN cleanvar sshd ZFS
+# REQUIRE: LOGIN NETWORK cleanvar ZFS
 # BEFORE:  securelevel
 # KEYWORD: shutdown
 


### PR DESCRIPTION
### Bugs
- rc.d/ioc requires NETWORK

### Enhancements
- do not fail stopping jails with invalid config properties
- do not fail executing commands in running jails with invalid config properties

### Chore
- allow updating rc.d/ioc with a separate Make command